### PR TITLE
Add the ability to specify custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,18 @@ api.fetch.retryWait((tries) => tries * 100)
 api.items().ids()
 ```
 
+### Specifying custom headers
+
+You can set custom headers to be sent with every API request, for example for attribution of requests made by your application.
+
+```js
+const headers = {
+  'X-Requested-By': 'my-cool-gw2-tool.com <my@email.com>'
+}
+
+api.headers(headers)
+```
+
 ### Extending
 
 You can extend or overwrite the API client with your own endpoints if you wish so. The only thing that is required is an extension of `AbstractEndpoint` to provide all the logic for pagination, bulk, localisation, caching and so on.

--- a/src/client.js
+++ b/src/client.js
@@ -11,6 +11,7 @@ export default class Client {
     this.apiKey = false
     this.fetch = fetch
     this.caches = [nullCache()]
+    this.headersObject = {}
   }
 
   // Set the language for locale-aware endpoints
@@ -31,6 +32,13 @@ export default class Client {
   cacheStorage (caches) {
     this.caches = [].concat(caches)
     debug(`updated the cache storage`)
+    return this
+  }
+
+  // Set the headers for all requests
+  headers (headers) {
+    this.headersObject = headers
+    debug(`updated the headers`)
     return this
   }
 

--- a/src/endpoint.js
+++ b/src/endpoint.js
@@ -14,6 +14,7 @@ export default class AbstractEndpoint {
     this.apiKey = parent.apiKey
     this.fetch = parent.fetch
     this.caches = parent.caches
+    this.headersObject = parent.headersObject
 
     this.baseUrl = 'https://api.guildwars2.com'
     this.isPaginated = false
@@ -427,14 +428,14 @@ export default class AbstractEndpoint {
   _request (url, type = 'json') {
     url = this._buildUrl(url)
     debugRequest(`single url ${url}`)
-    return this.fetch.single(url, {type})
+    return this.fetch.single(url, {type, headers: this.headersObject})
   }
 
   // Execute multiple requests in parallel
   _requestMany (urls, type = 'json') {
     urls = urls.map(url => this._buildUrl(url))
     debugRequest(`multiple urls ${urls.join(', ')}`)
-    return this.fetch.many(urls, {type})
+    return this.fetch.many(urls, {type, headers: this.headersObject})
   }
 
   // Build the headers for localization and authentication

--- a/tests/client.spec.js
+++ b/tests/client.spec.js
@@ -43,6 +43,12 @@ describe('client', () => {
     expect(client.caches).to.deep.equal([cacheHandler, cacheHandler])
   })
 
+  it('can set a header object', () => {
+    let api = client.headers({'X-Herp': 'Derp'})
+    expect(client.headersObject).to.deep.equal({'X-Herp': 'Derp'})
+    expect(api).to.be.an.instanceof(Module)
+  })
+
   it('can flush the caches if there is a game update', async () => {
     const tmp = client.build
     client.caches = [nullCache(), memoryCache(), memoryCache()]

--- a/tests/endpoint.spec.js
+++ b/tests/endpoint.spec.js
@@ -23,6 +23,14 @@ describe('abstract endpoint', () => {
     endpoint.caches.map(cache => cache.flush())
   })
 
+  it('recieves the client options', () => {
+    expect(endpoint.lang).to.equal('en')
+    expect(endpoint.apiKey).to.equal(false)
+    expect(typeof endpoint.fetch.single).to.equal('function')
+    expect(endpoint.caches.length).to.equal(3)
+    expect(endpoint.headersObject).to.deep.equal({})
+  })
+
   describe('ids', () => {
     it('support', async () => {
       let content = [1, 2]
@@ -900,6 +908,15 @@ describe('abstract endpoint', () => {
       expect(entry).to.deep.equal({foo: 'bar'})
     })
 
+    it('gives the headers to the underlying api for single requests', async () => {
+      fetchMock.addResponse({foo: 'bar'})
+      endpoint.headersObject = {'X-Herp': 'Derp'}
+
+      await endpoint._request('/v2/test')
+
+      expect(fetchMock.lastOption().headers).to.deep.equal({'X-Herp': 'Derp'})
+    })
+
     it('gives the type to the underlying api for multiple requests', async () => {
       endpoint.isLocalized = true
       fetchMock.addResponse({
@@ -922,6 +939,15 @@ describe('abstract endpoint', () => {
       let entry = await endpoint._requestMany(['/v2/test'])
       expect(fetchMock.lastUrl()).to.equal('https://api.guildwars2.com/v2/test?lang=en')
       expect(entry).to.deep.equal([{foo: 'bar'}])
+    })
+
+    it('gives the headers to the underlying api for multiple requests', async () => {
+      fetchMock.addResponse({foo: 'bar'})
+      endpoint.headersObject = {'X-Herp': 'Derp'}
+
+      await endpoint._requestMany(['/v2/test'])
+
+      expect(fetchMock.lastOption().headers).to.deep.equal({'X-Herp': 'Derp'})
     })
   })
 

--- a/tests/mocks/client.mock.js
+++ b/tests/mocks/client.mock.js
@@ -7,6 +7,7 @@ export const mockClient = {
   apiKey: false,
   fetch: fetch,
   caches: [nullCache(), memoryCache(), memoryCache()],
+  headersObject: {},
   language: function (lang) {
     this.lang = lang
   },


### PR DESCRIPTION
- [ ] Test if the headers get sent to the API
- [ ] Test CORS preflight requests

---

Handles #19

This will have to wait until the API is back, so I can check the actual responses.