### PR TITLE
Add missing custom params for various endpoints

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -1110,6 +1110,8 @@ Alternative method of calling [`api().commerce().transactions()`](#apicommercetr
 - **Authenticated:** Yes
 - **Localized:** No
 - **Cache time:** 5 minutes
+- **This endpoint exposes the following methods:**
+  - `since(:logId)` - Guild log with only entries that are newer than the given log id
 
 <sup>[↑ Back to the overview](#available-endpoints)</sup>
 

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -1702,6 +1702,8 @@ Alternative method of calling [`api().commerce().transactions()`](#apicommercetr
 - **Authenticated:** No
 - **Localized:** No
 - **Cache time:** 30 seconds
+- **This endpoint exposes the following methods:**
+  - `world(:worldId)` - Details of the WvW match where only the given world is participating in
 
 <sup>[↑ Back to the overview](#available-endpoints)</sup>
 
@@ -1717,6 +1719,8 @@ Alternative method of calling [`api().commerce().transactions()`](#apicommercetr
 - **Authenticated:** No
 - **Localized:** No
 - **Cache time:** 30 seconds
+- **This endpoint exposes the following methods:**
+  - `world(:worldId)` - Details of the WvW match where only the given world is participating in
 
 <sup>[↑ Back to the overview](#available-endpoints)</sup>
 
@@ -1732,6 +1736,8 @@ Alternative method of calling [`api().commerce().transactions()`](#apicommercetr
 - **Authenticated:** No
 - **Localized:** No
 - **Cache time:** 30 seconds
+- **This endpoint exposes the following methods:**
+  - `world(:worldId)` - Details of the WvW match where only the given world is participating in
 
 <sup>[↑ Back to the overview](#available-endpoints)</sup>
 
@@ -1747,6 +1753,8 @@ Alternative method of calling [`api().commerce().transactions()`](#apicommercetr
 - **Authenticated:** No
 - **Localized:** No
 - **Cache time:** 30 seconds
+- **This endpoint exposes the following methods:**
+  - `world(:worldId)` - Details of the WvW match where only the given world is participating in
 
 <sup>[↑ Back to the overview](#available-endpoints)</sup>
 

--- a/src/endpoints/guild.js
+++ b/src/endpoints/guild.js
@@ -97,6 +97,10 @@ class LogEndpoint extends AbstractEndpoint {
     this.isAuthenticated = true
     this.cacheTime = 5 * 60
   }
+
+  since (logId) {
+    return super.get(`?since=${logId}`, true);
+  }
 }
 
 class MembersEndpoint extends AbstractEndpoint {

--- a/src/endpoints/guild.js
+++ b/src/endpoints/guild.js
@@ -99,7 +99,7 @@ class LogEndpoint extends AbstractEndpoint {
   }
 
   since (logId) {
-    return super.get(`?since=${logId}`, true);
+    return super.get(`?since=${logId}`, true)
   }
 }
 

--- a/src/endpoints/wvw.js
+++ b/src/endpoints/wvw.js
@@ -42,6 +42,10 @@ class MatchesEndpoint extends AbstractEndpoint {
     this.cacheTime = 30
   }
 
+  world (worldId) {
+    return super.get(`?world=${worldId}`, true);
+  }
+
   overview () {
     return new MatchesOverviewEndpoint(this)
   }
@@ -63,6 +67,10 @@ class MatchesOverviewEndpoint extends AbstractEndpoint {
     this.isBulk = true
     this.cacheTime = 30
   }
+
+  world (worldId) {
+    return super.get(`?world=${worldId}`, true);
+  }
 }
 
 class MatchesScoresEndpoint extends AbstractEndpoint {
@@ -73,6 +81,10 @@ class MatchesScoresEndpoint extends AbstractEndpoint {
     this.isBulk = true
     this.cacheTime = 30
   }
+
+  world (worldId) {
+    return super.get(`?world=${worldId}`, true);
+  }
 }
 
 class MatchesStatsEndpoint extends AbstractEndpoint {
@@ -82,6 +94,10 @@ class MatchesStatsEndpoint extends AbstractEndpoint {
     this.isPaginated = true
     this.isBulk = true
     this.cacheTime = 30
+  }
+
+  world (worldId) {
+    return super.get(`?world=${worldId}`, true);
   }
 }
 

--- a/src/endpoints/wvw.js
+++ b/src/endpoints/wvw.js
@@ -43,7 +43,7 @@ class MatchesEndpoint extends AbstractEndpoint {
   }
 
   world (worldId) {
-    return super.get(`?world=${worldId}`, true);
+    return super.get(`?world=${worldId}`, true)
   }
 
   overview () {
@@ -69,7 +69,7 @@ class MatchesOverviewEndpoint extends AbstractEndpoint {
   }
 
   world (worldId) {
-    return super.get(`?world=${worldId}`, true);
+    return super.get(`?world=${worldId}`, true)
   }
 }
 
@@ -83,7 +83,7 @@ class MatchesScoresEndpoint extends AbstractEndpoint {
   }
 
   world (worldId) {
-    return super.get(`?world=${worldId}`, true);
+    return super.get(`?world=${worldId}`, true)
   }
 }
 
@@ -97,7 +97,7 @@ class MatchesStatsEndpoint extends AbstractEndpoint {
   }
 
   world (worldId) {
-    return super.get(`?world=${worldId}`, true);
+    return super.get(`?world=${worldId}`, true)
   }
 }
 

--- a/tests/endpoints/guild.spec.js
+++ b/tests/endpoints/guild.spec.js
@@ -86,6 +86,22 @@ describe('endpoints > guild', () => {
     expect(content[0].user).to.equal('Account.1234')
   })
 
+  it('test /v2/guild/:id/log (since)', async () => {
+    endpoint = (new Module(mockClient, 'S0ME-UU1D')).log()
+
+    expect(endpoint.isPaginated).to.equal(false)
+    expect(endpoint.isBulk).to.equal(false)
+    expect(endpoint.isLocalized).to.equal(false)
+    expect(endpoint.isAuthenticated).to.equal(true)
+    expect(endpoint.cacheTime).to.not.equal(undefined)
+    expect(endpoint.url).to.equal('/v2/guild/S0ME-UU1D/log')
+
+    fetchMock.addResponse([{id: 123, user: 'Account.1234', type: 'upgrade'}])
+    let content = await endpoint.since(42)
+    expect(content[0].user).to.equal('Account.1234')
+    expect(fetchMock.lastUrl()).contains('/v2/guild/S0ME-UU1D/log?since=42')
+  })
+
   it('test /v2/guild/:id/members', async () => {
     endpoint = (new Module(mockClient, 'S0ME-UU1D')).members()
 

--- a/tests/endpoints/wvw.spec.js
+++ b/tests/endpoints/wvw.spec.js
@@ -42,6 +42,23 @@ describe('endpoints > wvw', () => {
     expect(content.scores.red).to.equal(123)
   })
 
+  it('test /v2/wvw/matches (world)', async () => {
+    endpoint = endpoint.matches()
+
+    expect(endpoint.isPaginated).to.equal(true)
+    expect(endpoint.isBulk).to.equal(true)
+    expect(endpoint.supportsBulkAll).to.equal(true)
+    expect(endpoint.isLocalized).to.equal(false)
+    expect(endpoint.isAuthenticated).to.equal(false)
+    expect(endpoint.cacheTime).to.not.equal(undefined)
+    expect(endpoint.url).to.equal('/v2/wvw/matches')
+
+    fetchMock.addResponse({id: '2-6', worlds: {red: 2002, blue: 2007, green: 2202}, scores: {red: 123, blue: 456, green: 789}})
+    let content = await endpoint.world(2002)
+    expect(content.scores.red).to.equal(123)
+    expect(fetchMock.lastUrl()).contains('/v2/wvw/matches?world=2002')
+  })
+
   it('test /v2/wvw/matches/overview', async () => {
     endpoint = endpoint.matches().overview()
 
@@ -56,6 +73,23 @@ describe('endpoints > wvw', () => {
     fetchMock.addResponse({id: '2-6', worlds: {red: 2002, blue: 2007, green: 2202}})
     let content = await endpoint.get('2-6')
     expect(content.worlds.red).to.equal(2002)
+  })
+
+  it('test /v2/wvw/matches/overview (world)', async () => {
+    endpoint = endpoint.matches().overview()
+
+    expect(endpoint.isPaginated).to.equal(true)
+    expect(endpoint.isBulk).to.equal(true)
+    expect(endpoint.supportsBulkAll).to.equal(true)
+    expect(endpoint.isLocalized).to.equal(false)
+    expect(endpoint.isAuthenticated).to.equal(false)
+    expect(endpoint.cacheTime).to.not.equal(undefined)
+    expect(endpoint.url).to.equal('/v2/wvw/matches/overview')
+
+    fetchMock.addResponse({id: '2-6', worlds: {red: 2002, blue: 2007, green: 2202}})
+    let content = await endpoint.world(2002)
+    expect(content.worlds.red).to.equal(2002)
+    expect(fetchMock.lastUrl()).contains('/v2/wvw/matches/overview?world=2002')
   })
 
   it('test /v2/wvw/matches/scores', async () => {
@@ -74,6 +108,23 @@ describe('endpoints > wvw', () => {
     expect(content.scores.red).to.equal(123)
   })
 
+  it('test /v2/wvw/matches/scores (world)', async () => {
+    endpoint = endpoint.matches().scores()
+
+    expect(endpoint.isPaginated).to.equal(true)
+    expect(endpoint.isBulk).to.equal(true)
+    expect(endpoint.supportsBulkAll).to.equal(true)
+    expect(endpoint.isLocalized).to.equal(false)
+    expect(endpoint.isAuthenticated).to.equal(false)
+    expect(endpoint.cacheTime).to.not.equal(undefined)
+    expect(endpoint.url).to.equal('/v2/wvw/matches/scores')
+
+    fetchMock.addResponse({id: '2-6', worlds: {red: 2002, blue: 2007, green: 2202}, scores: {red: 123, blue: 456, green: 789}})
+    let content = await endpoint.world(2002)
+    expect(content.scores.red).to.equal(123)
+    expect(fetchMock.lastUrl()).contains('/v2/wvw/matches/scores?world=2002')
+  })
+
   it('test /v2/wvw/matches/stats', async () => {
     endpoint = endpoint.matches().stats()
 
@@ -88,6 +139,23 @@ describe('endpoints > wvw', () => {
     fetchMock.addResponse({id: '2-6', deaths: {red: 333, blue: 456, green: 789}})
     let content = await endpoint.get('2-6')
     expect(content.deaths.red).to.equal(333)
+  })
+
+  it('test /v2/wvw/matches/stats (world)', async () => {
+    endpoint = endpoint.matches().stats()
+
+    expect(endpoint.isPaginated).to.equal(true)
+    expect(endpoint.isBulk).to.equal(true)
+    expect(endpoint.supportsBulkAll).to.equal(true)
+    expect(endpoint.isLocalized).to.equal(false)
+    expect(endpoint.isAuthenticated).to.equal(false)
+    expect(endpoint.cacheTime).to.not.equal(undefined)
+    expect(endpoint.url).to.equal('/v2/wvw/matches/stats')
+
+    fetchMock.addResponse({id: '2-6', worlds: {red: 2002, blue: 2007, green: 2202}, deaths: {red: 333, blue: 456, green: 789}})
+    let content = await endpoint.world(2002)
+    expect(content.deaths.red).to.equal(333)
+    expect(fetchMock.lastUrl()).contains('/v2/wvw/matches/stats?world=2002')
   })
 
   it('test /v2/wvw/objectives', async () => {


### PR DESCRIPTION
This will add support for:
- `?since` to `/v2/guild/:id/log`
- `?world` to `/v2/wvw/matches`, `/v2/wvw/matches/overview`, `/v2/wvw/matches/scores`, `/v2/wvw/matches/stats`

I hope I didn't mess anything up while writing this during the API downtime.