### PR TITLE
Add credential flag (for custom endpoints)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,12 @@ import AbstractEndpoint from 'gw2api-client/build/endpoint'
 // Get an instance of an API client
 const api = client()
 
-// Define our custom "items" endpoint
+// Example: Add a new function inside the abstract endpoint
+AbstractEndpoint.prototype.post = function () {
+  console.log(this)
+}
+
+// Example: Define our custom "items" endpoint
 class ItemsEndpoint extends AbstractEndpoint {
   constructor (client) {
     super(client)
@@ -167,6 +172,9 @@ class ItemsEndpoint extends AbstractEndpoint {
     this.supportsBulkAll = false
     this.isLocalized = true
     this.cacheTime = 5 * 60
+
+    // Send credentials (e.g. session cookies)
+    this.credentials = true
   }
 }
 

--- a/src/endpoint.js
+++ b/src/endpoint.js
@@ -23,6 +23,7 @@ export default class AbstractEndpoint {
     this.isLocalized = false
     this.isAuthenticated = false
     this.isOptionallyAuthenticated = false
+    this.credentials = false
 
     this._skipCache = false
   }
@@ -427,14 +428,20 @@ export default class AbstractEndpoint {
   _request (url, type = 'json') {
     url = this._buildUrl(url)
     debugRequest(`single url ${url}`)
-    return this.fetch.single(url, {type})
+    return this.fetch.single(url, {
+      type,
+      credentials: this.credentials ? 'include' : undefined
+    })
   }
 
   // Execute multiple requests in parallel
   _requestMany (urls, type = 'json') {
     urls = urls.map(url => this._buildUrl(url))
     debugRequest(`multiple urls ${urls.join(', ')}`)
-    return this.fetch.many(urls, {type})
+    return this.fetch.many(urls, {
+      type,
+      credentials: this.credentials ? 'include' : undefined
+    })
   }
 
   // Build the headers for localization and authentication


### PR DESCRIPTION
This enables a flag in the abstract endpoint (and things that extend from it), so custom endpoints can force fetch to send credentials (e.g. session cookies).