### PR TITLE
Correct localization information for /v2/races

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -1661,7 +1661,7 @@ Alternative method of calling [`api().commerce().transactions()`](#apicommercetr
 - **Paginated:** Yes
 - **Bulk expanding:** Yes
 - **Authenticated:** No
-- **Localized:** No
+- **Localized:** Yes
 - **Cache time:** 24 hours
 
 <sup>[↑ Back to the overview](#available-endpoints)</sup>

--- a/src/endpoints/races.js
+++ b/src/endpoints/races.js
@@ -6,6 +6,7 @@ export default class RacesEndpoint extends AbstractEndpoint {
     this.url = '/v2/races'
     this.isPaginated = true
     this.isBulk = true
+    this.isLocalized = true
     this.cacheTime = 24 * 60 * 60
   }
 }

--- a/tests/endpoints/races.spec.js
+++ b/tests/endpoints/races.spec.js
@@ -14,7 +14,7 @@ describe('endpoints > races', () => {
     expect(endpoint.isPaginated).to.equal(true)
     expect(endpoint.isBulk).to.equal(true)
     expect(endpoint.supportsBulkAll).to.equal(true)
-    expect(endpoint.isLocalized).to.equal(false)
+    expect(endpoint.isLocalized).to.equal(true)
     expect(endpoint.isAuthenticated).to.equal(false)
     expect(endpoint.cacheTime).to.not.equal(undefined)
     expect(endpoint.url).to.equal('/v2/races')


### PR DESCRIPTION
The endpoint is actually localized. (See https://api.guildwars2.com/v2)

Example:

`https://api.guildwars2.com/v2/races?id=Human&lang=en`

```
{
  "id": "Human",
  "name": "Human",
  "skills": [
    12360,
    12361,
    12362,
    12363,
    12367,
    12373,
    10800
  ]
}
```

____

`https://api.guildwars2.com/v2/races?id=Human&lang=de`

```
{
  "id": "Human",
  "name": "Mensch",
  "skills": [
    12360,
    12361,
    12362,
    12363,
    12367,
    12373,
    10800
  ]
}
```