### PR TITLE
Fix caching id for /v2/characters

### DIFF
--- a/src/endpoint.js
+++ b/src/endpoint.js
@@ -19,6 +19,7 @@ module.exports = class AbstractEndpoint {
     this.isPaginated = false
     this.maxPageSize = 200
     this.isBulk = false
+    this.bulkId = 'id'
     this.supportsBulkAll = true
     this.isLocalized = false
     this.isAuthenticated = false
@@ -202,7 +203,7 @@ module.exports = class AbstractEndpoint {
       this.debugMessage(`many(${this.url}) resolving partially from cache (${cached.length} ids)`)
       const missingIds = getMissingIds(ids, cached)
       return this._many(missingIds, cached.length > 0).then(content => {
-        const cacheContent = content.map(value => [this._cacheHash(value.id), value])
+        const cacheContent = content.map(value => [this._cacheHash(value[this.bulkId]), value])
         this._cacheSetMany(cacheContent)
 
         // Merge the new content with the cached content and guarantee element order
@@ -215,7 +216,7 @@ module.exports = class AbstractEndpoint {
     const getMissingIds = (ids, cached) => {
       const cachedIds = {}
       cached.map(x => {
-        cachedIds[x.id] = 1
+        cachedIds[x[this.bulkId]] = 1
       })
 
       return ids.filter(x => cachedIds[x] !== 1)
@@ -288,7 +289,7 @@ module.exports = class AbstractEndpoint {
         let cacheContent = [[hash, content]]
 
         if (this.isBulk) {
-          cacheContent = cacheContent.concat(content.map(value => [this._cacheHash(value.id), value]))
+          cacheContent = cacheContent.concat(content.map(value => [this._cacheHash(value[this.bulkId]), value]))
         }
 
         this._cacheSetMany(cacheContent)
@@ -335,7 +336,7 @@ module.exports = class AbstractEndpoint {
         let cacheContent = [[hash, content]]
 
         if (this.isBulk) {
-          cacheContent = cacheContent.concat(content.map(value => [this._cacheHash(value.id), value]))
+          cacheContent = cacheContent.concat(content.map(value => [this._cacheHash(value[this.bulkId]), value]))
         }
 
         this._cacheSetMany(cacheContent)
@@ -521,7 +522,7 @@ module.exports = class AbstractEndpoint {
     })
 
     // Sort by the indexes
-    entries.sort((a, b) => indexMap[a.id] - indexMap[b.id])
+    entries.sort((a, b) => indexMap[a[this.bulkId]] - indexMap[b[this.bulkId]])
     return entries
   }
 

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -7,6 +7,7 @@ module.exports = class CharactersEndpoint extends AbstractEndpoint {
     this.url = '/v2/characters'
     this.isPaginated = true
     this.isBulk = true
+    this.bulkId = 'name'
     this.supportsBulkAll = false
     this.isAuthenticated = true
     this.cacheTime = 5 * 60

--- a/tests/endpoints/characters.spec.js
+++ b/tests/endpoints/characters.spec.js
@@ -12,6 +12,7 @@ describe('endpoints > characters', () => {
   it('test /v2/characters', async () => {
     expect(endpoint.isPaginated).toEqual(true)
     expect(endpoint.isBulk).toEqual(true)
+    expect(endpoint.bulkId).toEqual('name')
     expect(endpoint.supportsBulkAll).toEqual(false)
     expect(endpoint.isLocalized).toEqual(false)
     expect(endpoint.isAuthenticated).toEqual(true)


### PR DESCRIPTION
Previously, the non-existant "id" field was used for writing caching keys. Now we use the "name" field, that's actually the ID for this endpoint.
