### PR TITLE
Add localization prop to floors

### DIFF
--- a/src/endpoints/continents.js
+++ b/src/endpoints/continents.js
@@ -21,6 +21,7 @@ class FloorsEndpoint extends AbstractEndpoint {
     this.url = `/v2/continents/${continentId}/floors`
     this.isPaginated = true
     this.isBulk = true
+    this.isLocalized = true
     this.cacheTime = 24 * 60 * 60
   }
 }


### PR DESCRIPTION
Currently, the continents/floors endpoint doesn't support localization.

The GW2 API however does have localization, as can be seen on https://api.guildwars2.com/v2/continents/1/floors?ids=0&lang=de

Initial testing seems to show this working on my end with just this change (congrats on making that so easy to update!).