### PR TITLE
add bulk option to homestead decoration endpoint

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -397,10 +397,10 @@ Alternative method of calling [`api().commerce().delivery()`](#apicommercedelive
 > The account's currently used decorations in homestead.
 
 - **API-URL:** [/v2/account/homestead/decorations](https://api.guildwars2.com/v2/account/homestead/decorations)
-- **Paginated:** No
-- **Bulk expanding:** No
+- **Paginated:** Yes
+- **Bulk expanding:** Yes
 - **Authenticated:** Yes
-- **Localized:** No
+- **Localized:** Yes
 - **Cache time:** 5 minutes
 
 <sup>[↑ Back to the overview](#available-endpoints)</sup>

--- a/src/endpoints/homestead.js
+++ b/src/endpoints/homestead.js
@@ -16,6 +16,7 @@ class DecorationsEndpoint extends AbstractEndpoint {
     this.url = '/v2/homestead/decorations'
     this.isPaginated = true
     this.isLocalized = true
+    this.isBulk = true
     this.cacheTime = 24 * 60 * 60
   }
 


### PR DESCRIPTION
The homestead/decorations api is capable of supporting bulk calls, as given by the example url: [https://api.guildwars2.com/v2/homestead/decorations?ids=2,4,6](https://api.guildwars2.com/v2/homestead/decorations?ids=2,4,6)